### PR TITLE
Add missing `#include <optional>` and `#include <stdexcept>`

### DIFF
--- a/src/include/parser.hpp
+++ b/src/include/parser.hpp
@@ -2,6 +2,7 @@
 #define DOT_PARSER_PARSER_HPP
 
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/include/parser.hpp
+++ b/src/include/parser.hpp
@@ -1,6 +1,7 @@
 #ifndef DOT_PARSER_PARSER_HPP
 #define DOT_PARSER_PARSER_HPP
 
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
Fixes:
```
/home/user/projects/tight_isometric/submodules/graphlite/lib/dot_parser_cpp/src/include/parser.hpp:223:27: error: ‘optional’ in namespace ‘std’ does not name a template type
  223 |             [](const std::optional<std::string>& strict,
      |                           ^~~~~~~~
In file included from /home/user/projects/tight_isometric/submodules/graphlite/lib/dot_parser_cpp/src/parser.cpp:1:
/home/user/projects/tight_isometric/submodules/graphlite/lib/dot_parser_cpp/src/include/parser.hpp:10:1: note: ‘std::optional’ is defined in header ‘<optional>’; did you forget to ‘#include <optional>’?
    9 | #include "non_terminals.hpp"
  +++ |+#include <optional>
   10 | 
In file included from /home/user/projects/tight_isometric/submodules/graphlite/lib/dot_parser_cpp/src/parser.cpp:1:
/home/user/projects/tight_isometric/submodules/graphlite/lib/dot_parser_cpp/src/include/parser.hpp: In lambda function:
/home/user/projects/tight_isometric/submodules/graphlite/lib/dot_parser_cpp/src/include/parser.hpp:232:10: error: expected ‘{’ before ‘;’ token
  232 |         );
      |          ^
/home/user/projects/tight_isometric/submodules/graphlite/lib/dot_parser_cpp/src/include/parser.hpp: At global scope:
/home/user/projects/tight_isometric/submodules/graphlite/lib/dot_parser_cpp/src/include/parser.hpp:232:10: error: expected ‘)’ before ‘;’ token
  232 |         );
      |          ^
      |          )
/home/user/projects/tight_isometric/submodules/graphlite/lib/dot_parser_cpp/src/include/parser.hpp:222:68: note: to match this ‘(’
  222 |         static constexpr auto value = lexy::callback<dot_graph_raw>(
      |           
```